### PR TITLE
fix: add azd auth login for OIDC federated credentials

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -49,6 +49,13 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Log in to azd (federated)
+        run: |
+          azd auth login \
+            --client-id "${{ secrets.AZURE_CLIENT_ID }}" \
+            --federated-credential-provider github \
+            --tenant-id "${{ secrets.AZURE_TENANT_ID }}"
+
       - name: Select or create azd environment
         run: |
           ENV_NAME="agentcraftworks-${{ github.event.inputs.environment }}"
@@ -107,6 +114,13 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Log in to azd (federated)
+        run: |
+          azd auth login \
+            --client-id "${{ secrets.AZURE_CLIENT_ID }}" \
+            --federated-credential-provider github \
+            --tenant-id "${{ secrets.AZURE_TENANT_ID }}"
 
       - name: Get app URL
         id: env


### PR DESCRIPTION
## Problem

The \deploy-azd.yml\ workflow was failing at the \zd up\ step with:

> ERROR: not logged in, run \zd auth login\ to login

\zure/login@v2\ only authenticates **Azure CLI** (\z\), but \zd\ (Azure Developer CLI) has a separate auth context and was not authenticated.

## Fix

Added \zd auth login --federated-credential-provider github\ after each \zure/login\ step in both the \deploy\ and \smoke-tests\ jobs. This tells \zd\ to obtain a federated token from the GitHub Actions OIDC provider, matching the Federated Identity Credentials configured on the app registration.

## Also fixed (prior to this PR)

Updated the production FIC subject from \nvironment:prod\ to \nvironment:production\ to match the GitHub environment name exactly.