### PR TITLE
fix: disable auto-deploy on push to main until infra ready

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -2,8 +2,6 @@ name: Deploy to Production
 
 on:
   push:
-    branches:
-      - main
     tags:
       - "v*"
   workflow_dispatch:


### PR DESCRIPTION
Removes the \ranches: [main]\ push trigger from \deploy-production.yml\ so it only fires on version tags (\*\) or manual dispatch.

This prevents CI failures from missing ACR/Container App secrets while \deploy-azd.yml\ infrastructure provisioning is still being set up. Once secrets are populated, re-add the \main\ branch trigger.