### PR TITLE
fix: convert azure.yaml resources from sequence to map

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -18,12 +18,11 @@ services:
 
 # Infrastructure resources
 resources:
-  - name: postgres
+  postgres:
     type: postgres
     uses:
       - typescript-api
-
-  - name: redis
+  redis:
     type: redis
     uses:
       - typescript-api


### PR DESCRIPTION
azd requires \esources\ to be a YAML map, not a sequence (list). The current syntax uses \- name: postgres\ list items which causes:

> line 21: cannot unmarshal !!seq into map[string]*project.ResourceConfig

Changed to map syntax where each resource name is a key.