### PR TITLE
fix: set environmentName and AZURE_LOCATION for azd provisioning

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -63,6 +63,8 @@ jobs:
             azd env new "$ENV_NAME" \
               --subscription "${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
               --location "${{ secrets.AZURE_LOCATION }}"
+          azd env set AZURE_LOCATION "${{ secrets.AZURE_LOCATION }}"
+          azd env set environmentName "$ENV_NAME"
 
       - name: Configure environment secrets
         run: |


### PR DESCRIPTION
azd up --no-prompt fails because main.bicep has a required environmentName parameter with no default. Added azd env set calls to pre-populate both environmentName and AZURE_LOCATION so Bicep receives them without interactive prompting.