### PR TITLE
fix: align azd env var names with Bicep parameter names

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -63,14 +63,15 @@ jobs:
             azd env new "$ENV_NAME" \
               --subscription "${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
               --location "${{ secrets.AZURE_LOCATION }}"
+          azd env set AZURE_ENV_NAME "$ENV_NAME"
           azd env set AZURE_LOCATION "${{ secrets.AZURE_LOCATION }}"
-          azd env set environmentName "$ENV_NAME"
 
       - name: Configure environment secrets
         run: |
-          azd env set GH_APP_ID "${{ secrets.GH_APP_ID }}"
-          azd env set GH_WEBHOOK_SECRET "${{ secrets.GH_WEBHOOK_SECRET }}"
-          azd env set GH_APP_PRIVATE_KEY "${{ secrets.GH_APP_PRIVATE_KEY }}"
+          azd env set ghAppId "${{ secrets.GH_APP_ID }}"
+          azd env set ghWebhookSecret "${{ secrets.GH_WEBHOOK_SECRET }}"
+          azd env set ghAppPrivateKey "${{ secrets.GH_APP_PRIVATE_KEY }}"
+          azd env set postgresPassword "$(openssl rand -base64 32)"
 
       - name: Run azd (provision + deploy)
         if: github.event.inputs.action == 'up (provision + deploy)'


### PR DESCRIPTION
Three issues causing azd provision to prompt for environmentName:

1. **environmentName**: azd auto-resolves this well-known param from AZURE_ENV_NAME, not from a literal environmentName env var. Changed to set AZURE_ENV_NAME explicitly.

2. **Param name mismatch**: azd env vars must match Bicep param names exactly. GH_APP_ID does not match ghAppId. Changed all secret env vars to use exact camelCase matching Bicep params (ghAppId, ghWebhookSecret, ghAppPrivateKey).

3. **Missing postgresPassword**: Required Bicep param with no default was never set in the workflow. Added auto-generation via openssl rand. Note: this generates a new password each provision run. Add a POSTGRES_PASSWORD secret if a fixed password is needed.