### PR TITLE
fix: restore environmentName Bicep param (regressed in PR #16)

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -63,14 +63,16 @@ jobs:
             azd env new "$ENV_NAME" \
               --subscription "${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
               --location "${{ secrets.AZURE_LOCATION }}"
-          azd env set AZURE_ENV_NAME "$ENV_NAME"
+          azd env set environmentName "$ENV_NAME"
           azd env set AZURE_LOCATION "${{ secrets.AZURE_LOCATION }}"
 
       - name: Configure environment secrets
+        env:
+          GH_APP_PRIVATE_KEY_VALUE: ${{ secrets.GH_APP_PRIVATE_KEY }}
         run: |
           azd env set ghAppId "${{ secrets.GH_APP_ID }}"
           azd env set ghWebhookSecret "${{ secrets.GH_WEBHOOK_SECRET }}"
-          azd env set ghAppPrivateKey "${{ secrets.GH_APP_PRIVATE_KEY }}"
+          azd env set ghAppPrivateKey "$GH_APP_PRIVATE_KEY_VALUE"
           azd env set postgresPassword "$(openssl rand -base64 32)"
 
       - name: Run azd (provision + deploy)


### PR DESCRIPTION
## Problem

PR #16 inadvertently regressed the `environmentName` fix from PR #15.

**PR #15** correctly used:
```
azd env set environmentName "$ENV_NAME"
```
This maps directly to the Bicep `param environmentName string`.

**PR #16** changed it to:
```
azd env set AZURE_ENV_NAME "$ENV_NAME"
```
`AZURE_ENV_NAME` is NOT a Bicep parameter name — azd doesn't map it to the `environmentName` param, causing the persistent `Enter a value for the 'environmentName' infrastructure parameter` prompt.

## Fix

1. **Restore `environmentName`**: Revert `AZURE_ENV_NAME` back to `environmentName` so azd correctly passes it to Bicep.
2. **Fix multiline PEM key handling**: Pass `GH_APP_PRIVATE_KEY` via a step-level `env` variable instead of inline `${{ secrets.* }}` expansion, avoiding shell interpolation issues with the multiline PEM content.

## Root Cause

The camelCase param rename work in PR #16 accidentally changed the _azd env key_ (`environmentName`) to something else (`AZURE_ENV_NAME`), not realizing `environmentName` was already the correct Bicep param name.

## Verification

After merge, trigger `deploy-azd.yml` with `provision (infrastructure only)` on `production`. The `environmentName` prompt should no longer appear.