### PR TITLE
fix: use if/fi instead of || to prevent bash -e from skipping azd env set

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -57,14 +57,20 @@ jobs:
             --tenant-id "${{ secrets.AZURE_TENANT_ID }}"
 
       - name: Select or create azd environment
+        env:
+          ENV_NAME: "agentcraftworks-${{ github.event.inputs.environment }}"
         run: |
-          ENV_NAME="agentcraftworks-${{ github.event.inputs.environment }}"
-          azd env select "$ENV_NAME" 2>/dev/null || \
+          if ! azd env select "$ENV_NAME" 2>/dev/null; then
+            echo "Creating new azd environment: $ENV_NAME"
             azd env new "$ENV_NAME" \
               --subscription "${{ secrets.AZURE_SUBSCRIPTION_ID }}" \
               --location "${{ secrets.AZURE_LOCATION }}"
+          fi
+
+          echo "Setting environmentName and AZURE_LOCATION..."
           azd env set environmentName "$ENV_NAME"
           azd env set AZURE_LOCATION "${{ secrets.AZURE_LOCATION }}"
+          echo "Done configuring azd environment."
 
       - name: Configure environment secrets
         env:


### PR DESCRIPTION
## Problem

The `azd env set environmentName` and `azd env set AZURE_LOCATION` commands in the "Select or create azd environment" step **never actually execute**. This is confirmed by the run logs for [run 22539711968](https://github.com/AgentCraftworks/AgentCraftworks-CE/actions/runs/22539711968/job/65292968284) — the step output shows:

```
ERROR: environment 'agentcraftworks-production' does not exist...
New environment 'agentcraftworks-production' was set as default
```

...and then immediately jumps to the next step. No output from `azd env set environmentName` or `azd env set AZURE_LOCATION` appears.

## Root Cause

The `||` compound command pattern under `bash -e`:

```bash
azd env select "$ENV_NAME" 2>/dev/null || \
  azd env new "$ENV_NAME" --subscription "..." --location "..."
azd env set environmentName "$ENV_NAME"   # ← never reaches here
```

`bash -e` (set by GitHub Actions' `shell: /usr/bin/bash -e {0}`) causes the script to exit after the `||` compound command completes, silently skipping subsequent commands. This is a known `bash -e` edge case with `||` constructs.

## Fix

Replace the `||` pattern with an explicit `if ! ...; then ...; fi` block:

```bash
if ! azd env select "$ENV_NAME" 2>/dev/null; then
  azd env new "$ENV_NAME" --subscription "..." --location "..."
fi
azd env set environmentName "$ENV_NAME"   # ← now executes reliably
```

The `!` negation inside an `if` condition is explicitly exempt from `set -e` behavior per POSIX spec, making this pattern safe.

Also adds echo breadcrumbs for log visibility so we can confirm execution in future runs.

## Previous context

- PR #18 restored `environmentName` (was regressed to `AZURE_ENV_NAME` in PR #16)
- The param name was correct but the command never executed due to this bash -e issue
- Secret rename `GH_PRIVATE_KEY` → `GH_APP_PRIVATE_KEY` was done in environment settings (separate from this PR)