### PR TITLE
fix: add main.parameters.json for azd Bicep parameter resolution

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -67,8 +67,8 @@ jobs:
               --location "${{ secrets.AZURE_LOCATION }}"
           fi
 
-          echo "Setting environmentName and AZURE_LOCATION..."
-          azd env set environmentName "$ENV_NAME"
+          echo "Setting environment parameters..."
+          azd env set AZURE_ENV_NAME "$ENV_NAME"
           azd env set AZURE_LOCATION "${{ secrets.AZURE_LOCATION }}"
           echo "Done configuring azd environment."
 

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "principalId": {
+      "value": "${AZURE_PRINCIPAL_ID}"
+    },
+    "postgresPassword": {
+      "value": "${postgresPassword}"
+    },
+    "ghWebhookSecret": {
+      "value": "${ghWebhookSecret}"
+    },
+    "ghAppId": {
+      "value": "${ghAppId}"
+    },
+    "ghAppPrivateKey": {
+      "value": "${ghAppPrivateKey}"
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Despite PR #18 (correct param name) and PR #20 (fix bash -e execution), `azd provision --no-prompt` still prompts for `environmentName`. Run [22540010589](https://github.com/AgentCraftworks/AgentCraftworks-CE/actions/runs/22540010589/job/65293721934) confirms that `azd env set environmentName` **now executes** (breadcrumbs visible in logs), yet azd still can't resolve the parameter.

## Root Cause

**`azd env set` does NOT automatically pass values to Bicep parameters.** azd stores values in its `.env` file, but to map them to Bicep params, it requires a `main.parameters.json` file using `${VAR}` syntax. Without this file, azd only resolves a handful of built-in parameters (`location` from `AZURE_LOCATION`) and prompts for everything else.

This is the standard azd convention documented in the [azd templates](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/azd-templates).

## Fix

**Add `infra/main.parameters.json`** — maps every Bicep parameter to its corresponding azd environment variable:

| Bicep Parameter | azd env key | Source |
|----------------|-------------|--------|
| `environmentName` | `${AZURE_ENV_NAME}` | Set in "Select or create" step |
| `location` | `${AZURE_LOCATION}` | GitHub environment secret |
| `principalId` | `${AZURE_PRINCIPAL_ID}` | Optional (empty = Bicep default `''`) |
| `postgresPassword` | `${postgresPassword}` | Set in "Configure secrets" step |
| `ghWebhookSecret` | `${ghWebhookSecret}` | Set in "Configure secrets" step |
| `ghAppId` | `${ghAppId}` | Set in "Configure secrets" step |
| `ghAppPrivateKey` | `${ghAppPrivateKey}` | Set in "Configure secrets" step |

Also updates the workflow to set `AZURE_ENV_NAME` (the azd well-known key referenced in parameters.json) instead of raw `environmentName`.

## Timeline of fixes
- PR #18: Corrected param name (`AZURE_ENV_NAME` → `environmentName`) ← right idea, wrong mechanism
- PR #20: Fixed bash -e skipping `azd env set` commands ← real bug, but `env set` alone isn't enough  
- **This PR**: Adds the missing `main.parameters.json` that azd actually uses to resolve Bicep params ← the actual missing piece