### PR TITLE
fix: remove @secure() params from parameters.json to fix newline parse error

### DIFF
--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -10,18 +10,6 @@
     },
     "principalId": {
       "value": "${AZURE_PRINCIPAL_ID}"
-    },
-    "postgresPassword": {
-      "value": "${postgresPassword}"
-    },
-    "ghWebhookSecret": {
-      "value": "${ghWebhookSecret}"
-    },
-    "ghAppId": {
-      "value": "${ghAppId}"
-    },
-    "ghAppPrivateKey": {
-      "value": "${ghAppPrivateKey}"
     }
   }
 }


### PR DESCRIPTION
Remove @secure() params from main.parameters.json. The PEM private key newlines break JSON parsing. azd resolves @secure() Bicep params directly from 'azd env set' values — no parameters.json entry needed.