### PR TITLE
fix: restore @secure() params in parameters.json, escape PEM newlines

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -79,7 +79,11 @@ jobs:
         run: |
           azd env set ghAppId "${{ secrets.GH_APP_ID }}"
           azd env set ghWebhookSecret "${{ secrets.GH_WEBHOOK_SECRET }}"
-          azd env set ghAppPrivateKey "$GH_APP_PRIVATE_KEY_VALUE"
+
+          # Store PEM key as single line to avoid JSON parse errors in parameters.json substitution.
+          # azd env set writes to .env; multiline values break JSON when ${ghAppPrivateKey} is resolved.
+          SINGLE_LINE_KEY=$(printf '%s' "$GH_APP_PRIVATE_KEY_VALUE" | tr '\n' '|' | sed 's/|/\\n/g')
+          azd env set ghAppPrivateKey "$SINGLE_LINE_KEY"
 
           # Prefer a stable password from POSTGRES_PASSWORD secret when provided.
           if [ -n "$POSTGRES_PASSWORD_SECRET" ]; then

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -10,6 +10,18 @@
     },
     "principalId": {
       "value": "${AZURE_PRINCIPAL_ID}"
+    },
+    "postgresPassword": {
+      "value": "${postgresPassword}"
+    },
+    "ghWebhookSecret": {
+      "value": "${ghWebhookSecret}"
+    },
+    "ghAppId": {
+      "value": "${ghAppId}"
+    },
+    "ghAppPrivateKey": {
+      "value": "${ghAppPrivateKey}"
     }
   }
 }


### PR DESCRIPTION
## Problem

Run [22540449922](https://github.com/AgentCraftworks/AgentCraftworks-CE/actions/runs/22540449922) panicked with:

\\\
panic: don't know how to prompt for type *survey.Password
\\\

azd could not resolve the 4 \@secure()\ Bicep parameters (\postgresPassword\, \ghWebhookSecret\, \ghAppId\, \ghAppPrivateKey\) that were removed from \main.parameters.json\ in PR #22. Without entries in \parameters.json\, azd falls back to interactive prompting — which panics in \--no-prompt\ mode.

## Root Cause

PR #22 removed the \@secure()\ params from \parameters.json\ to fix a JSON parse error caused by the PEM private key's literal newlines breaking JSON when azd substituted \\\. That fixed the JSON parse error but created this new panic.

## Fix

1. **Restore all 4 \@secure()\ params** in \infra/main.parameters.json\ with \\\ references
2. **Escape PEM newlines** before storing via \zd env set\ — converts multiline PEM to single-line representation (\\\n\ → literal \\n\ two-char sequence). When azd substitutes into JSON, the \\n\ is a valid JSON escape. JSON parsing restores real newlines.

## Changes

- \infra/main.parameters.json\ — Add back \postgresPassword\, \ghWebhookSecret\, \ghAppId\, \ghAppPrivateKey\
- \.github/workflows/deploy-azd.yml\ — Convert PEM key to single-line before \zd env set\

Fixes the azd \--no-prompt\ panic from run 22540449922.