### PR TITLE
fix: add dependsOn for RBAC role assignments before Container App

### DIFF
--- a/infra/app-ts.bicep
+++ b/infra/app-ts.bicep
@@ -48,10 +48,16 @@ resource acrPullRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
 }
 
 // TypeScript Container App
+// dependsOn ensures RBAC role assignments propagate before the Container App
+// tries to pull secrets from Key Vault or images from ACR via managed identity.
 resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
   name: 'ca-ts-${resourceToken}'
   location: location
   tags: tags
+  dependsOn: [
+    keyVaultSecretsUserRole
+    acrPullRole
+  ]
   identity: {
     type: 'UserAssigned'
     userAssignedIdentities: {


### PR DESCRIPTION
## Problem

Run 22541126513 provisioned all infrastructure successfully (RG, ACR, CAE, PostgreSQL, Redis, Key Vault) but the **Container App failed** with:

\\\
ContainerAppOperationError: Unable to get value using Managed identity .../id-app-ts-o5va4ojdnwq56 for secret gh-app-id
\\\

## Root Cause

In \pp-ts.bicep\, the Container App and the \keyVaultSecretsUserRole\ role assignment are deployed **in parallel** by ARM because the Container App doesn't reference the role assignment resource. Bicep sees no implicit dependency between them, so it submits both simultaneously. The Container App tries to pull KV secrets via the managed identity before the role assignment has propagated.

## Fix

Add explicit \dependsOn: [keyVaultSecretsUserRole, acrPullRole]\ to the Container App resource to ensure both RBAC role assignments complete (and propagate) before the Container App is provisioned.

## Changes

- \infra/app-ts.bicep\ — Add \dependsOn\ for Key Vault Secrets User and ACR Pull role assignments