### PR TITLE
fix: add environment to smoke-tests job for OIDC FIC match

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -121,6 +121,7 @@ jobs:
     name: Run Smoke Tests
     needs: deploy
     runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
     if: "!contains(github.event.inputs.action, 'down')"
 
     steps:


### PR DESCRIPTION
The smoke-tests job uses OIDC login but lacked the environment setting, causing AADSTS700213.