### PR TITLE
fix: skip smoke tests for provision-only and down actions

### DIFF
--- a/.github/workflows/deploy-azd.yml
+++ b/.github/workflows/deploy-azd.yml
@@ -122,7 +122,7 @@ jobs:
     needs: deploy
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment }}
-    if: "!contains(github.event.inputs.action, 'down')"
+    if: contains(github.event.inputs.action, 'up') || contains(github.event.inputs.action, 'deploy')
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Smoke tests only make sense when an app is deployed (up or deploy). For provision-only, only placeholder infra exists.