### PR TITLE
docs: update org standards hierarchy — CE consumes standards from AgentCraftworks (paid)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,7 +434,7 @@ Bootstrap assets for this policy:
 
 **All strategy evaluations, forward-looking plans, roadmaps, and proposals MUST be:**
 
-1. **Labeled** with status `DRAFT — FUTURE / UNDER EVALUATION` in their front matter
+1. **Labeled** with status `DRAFT` in their front matter
 2. **Placed** in `docs/futures/` (not in `docs/` root)
 3. **Never mixed** with documentation for shipped/implemented features
 


### PR DESCRIPTION
## Summary

Updates the org standards hierarchy to explicitly declare that AgentCraftworks-CE **consumes** product-specific agent standards from the paid `AgentCraftworks` repo, and adds the futures documentation policy.

### Changes

**AGENTS.md updates:**

1. **Org boundary table** — splits Product into **Paid** (`AgentCraftworks`) and **OSS** (`CE`, `VSCode`, `WebSite`) with explicit audience and auth columns

2. **Standards hierarchy section** — new subsection explaining:
   - Product-specific standards are authored in `AgentCraftworks` (paid product)
   - This repo consumes them via `ORG-STANDARD` sync
   - PlatformOps is the central hub for org-wide engineering standards

3. **Rule 6** — "This repo consumes product standards from `AgentCraftworks` — do not create new product standards here"

4. **Standards flow diagram** updated:
   ```
   PlatformOps (org-wide engineering)
       ↓
   AgentCraftworks (product-specific — source of truth)
       ↓
   AgentCraftworks-CE (this repo — consumer)
   ```

5. **Documentation Standards — Futures vs Implemented** — new section requiring forward-looking docs in `docs/futures/`, status labels, and separation from shipped docs

### Coordinated PRs

- **AgentCraftworks** — AgentCraftworks/AgentCraftworks#426
- **AgentCraftworks-CE** (this PR)
- **AgentCraftworks-PlatformOps** — `docs/org-standards-hierarchy-futures`
- **AgentCraftworks-BizOps** — `docs/org-standards-hierarchy-futures`

### Note

This branch includes branching policy content that overlaps with PR #37 (`feat: add branch-policy bootstrap script and guard`). If PR #37 merges first, a rebase may be needed to remove the duplicate section.