### PR TITLE
fix: remove branch naming restrictions for PRs into staging

### DIFF
--- a/.github/workflows/ghaw-branch-policy-guard.yml
+++ b/.github/workflows/ghaw-branch-policy-guard.yml
@@ -1,6 +1,7 @@
 name: "GH-AW: Branch Policy Guard"
 
-# Enforces promotion flow: feature/* -> staging -> main.
+# Enforces promotion flow: staging -> main only.
+# Staging accepts PRs from any branch; main only accepts staging.
 # Engagement Level: T1 (Observer) - validates PR branch topology only.
 
 on:
@@ -32,16 +33,14 @@ jobs:
 
                   echo "PR flow: ${HEAD} -> ${BASE}"
 
+                  # Only enforce branch naming for PRs into main (must come from staging)
                   if [[ "${BASE}" == "main" ]]; then
                     if [[ "${HEAD}" != "staging" ]]; then
                       echo "::error::PRs into main must come from staging. Got ${HEAD} -> main."
                       exit 1
                     fi
-                  elif [[ "${BASE}" == "staging" ]]; then
-                    if [[ ! "${HEAD}" =~ ^(feature|feat|fix|hotfix|chore|docs)/.+$ ]]; then
-                      echo "::error::PRs into staging must come from feature/fix/hotfix/chore/docs branches. Got ${HEAD}."
-                      exit 1
-                    fi
                   fi
+                  
+                  # Staging accepts PRs from any branch - no name restrictions
 
                   echo "Branch policy guard passed."


### PR DESCRIPTION
## Problem

PR #77 is failing branch policy validation:
```
PRs into staging must come from feature/fix/hotfix/chore/docs branches. Got Jenp-AICraftWorks-patch-1.
```

The branch policy guard workflow currently enforces naming patterns for **both** staging and main:
- ❌ **staging**: requires `feature/*`, `feat/*`, `fix/*`, `hotfix/*`, `chore/*`, or `docs/*` prefixes  
- ✅ **main**: requires PRs from `staging` only (correct)

This is overly restrictive for staging, which should accept contributions from any branch name (including GitHub's auto-generated patch branches).

## Solution

**Relaxed staging branch policy** while keeping main protected:
- ✅ **staging**: accepts PRs from **any branch**  
- ✅ **main**: still requires PRs from **`staging` only**

## Changes
- Updated workflow comment to reflect new policy
- Removed `elif` block enforcing staging branch naming pattern  
- Added clarifying comment: "Staging accepts PRs from any branch - no name restrictions"

## Impact
After merge:
- ✅ PR #77 (`Jenp-AICraftWorks-patch-1`) will pass validation
- ✅ GitHub patch branches can merge to staging
- ✅ Community contributors don't need to know naming conventions
- ✅ Main branch protection unchanged (still requires staging → main flow)

## Testing
This change affects the `ghaw-branch-policy-guard.yml` workflow which runs on PR open/sync. Once merged:
1. PR #77 can be re-run and will pass
2. Future PRs to staging from any branch name will succeed
3. PRs to main still require `staging` source branch (unchanged)

Resolves https://github.com/AgentCraftworks/AgentCraftworks-CE/actions/runs/22786580070/job/66104523247
