### PR TITLE
feat: Add GH-AW Secret Rotation Reminder workflow

### DIFF
--- a/.github/security/secret-rotation-policy.json
+++ b/.github/security/secret-rotation-policy.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "defaultMaxAgeDays": 90,
+  "reminderDaysBeforeExpiry": 14,
+  "issue": {
+    "title": "[Security] Secret rotation reminder",
+    "labels": ["security", "secret-rotation"]
+  },
+  "secrets": [
+    {
+      "name": "GH_CE_APP_PRIVATE_KEY",
+      "environment": "production",
+      "owner": "platform-engineering",
+      "maxAgeDays": 90,
+      "lastRotated": "2026-03-10",
+      "notes": "GitHub CE App private key"
+    },
+    {
+      "name": "GH_CE_WEBHOOK_SECRET",
+      "environment": "production",
+      "owner": "platform-engineering",
+      "maxAgeDays": 90,
+      "lastRotated": "2026-03-10",
+      "notes": "GitHub CE App webhook secret"
+    },
+    {
+      "name": "POSTGRES_PASSWORD",
+      "environment": "production",
+      "owner": "platform-engineering",
+      "maxAgeDays": 90,
+      "lastRotated": "2026-03-10",
+      "notes": "PostgreSQL database password for MCP server"
+    }
+  ]
+}

--- a/.github/workflows/ghaw-secret-rotation-reminder.yml
+++ b/.github/workflows/ghaw-secret-rotation-reminder.yml
@@ -1,0 +1,148 @@
+name: "GH-AW: Secret Rotation Reminder"
+
+# Tracks token age for repo secrets and creates reminder issues.
+# Engagement Level: T2 (Advisor) - creates/updates issue reminders only.
+
+on:
+    schedule:
+        - cron: "17 15 * * 1"
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    issues: write
+
+concurrency:
+    group: secret-rotation-reminder
+    cancel-in-progress: false
+
+jobs:
+    remind-secret-rotation:
+        name: Evaluate Secret Rotation Policy
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Evaluate policy and manage reminder issue
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const fs = require('node:fs');
+                      const path = '.github/security/secret-rotation-policy.json';
+                      const policy = JSON.parse(fs.readFileSync(path, 'utf8'));
+
+                      const now = new Date();
+                      const msPerDay = 24 * 60 * 60 * 1000;
+                      const reminderDays = policy.reminderDaysBeforeExpiry ?? 14;
+                      const defaultMaxAgeDays = policy.defaultMaxAgeDays ?? 90;
+                      const issueTitle = policy.issue?.title ?? '[Security] Secret rotation reminder';
+                      const issueLabels = policy.issue?.labels ?? ['security', 'secret-rotation'];
+
+                      const due = [];
+
+                      for (const secret of policy.secrets ?? []) {
+                        const maxAgeDays = secret.maxAgeDays ?? defaultMaxAgeDays;
+                        const rotated = new Date(secret.lastRotated);
+                        if (Number.isNaN(rotated.getTime())) {
+                          due.push({
+                            ...secret,
+                            maxAgeDays,
+                            daysUntilExpiry: Number.NEGATIVE_INFINITY,
+                            status: 'invalid-date',
+                            message: `Invalid lastRotated value: ${secret.lastRotated}`
+                          });
+                          continue;
+                        }
+
+                        const ageDays = Math.floor((now - rotated) / msPerDay);
+                        const daysUntilExpiry = maxAgeDays - ageDays;
+
+                        if (daysUntilExpiry <= reminderDays) {
+                          due.push({
+                            ...secret,
+                            maxAgeDays,
+                            ageDays,
+                            daysUntilExpiry,
+                            status: daysUntilExpiry < 0 ? 'overdue' : 'due-soon'
+                          });
+                        }
+                      }
+
+                      const { owner, repo } = context.repo;
+                      const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+                        owner,
+                        repo,
+                        state: 'open',
+                        labels: issueLabels.join(','),
+                        per_page: 100
+                      });
+
+                      const trackingIssue = openIssues.find((i) => i.title === issueTitle);
+
+                      if (due.length === 0) {
+                        if (trackingIssue) {
+                          await github.rest.issues.createComment({
+                            owner,
+                            repo,
+                            issue_number: trackingIssue.number,
+                            body: 'All tracked secrets are currently within rotation policy. Closing this reminder issue.'
+                          });
+                          await github.rest.issues.update({
+                            owner,
+                            repo,
+                            issue_number: trackingIssue.number,
+                            state: 'closed'
+                          });
+                        }
+                        core.info('No due or overdue secrets found.');
+                        return;
+                      }
+
+                      const lines = [];
+                      lines.push('## Secret Rotation Reminder');
+                      lines.push('The following secrets are due or overdue for rotation based on policy.');
+                      lines.push('');
+                      lines.push('| Secret | Environment | Owner | Age (days) | Max Age (days) | Days Until Expiry | Status |');
+                      lines.push('|---|---|---|---:|---:|---:|---|');
+
+                      for (const item of due) {
+                        if (item.status === 'invalid-date') {
+                          lines.push(`| ${item.name ?? 'unknown'} | ${item.environment ?? '-'} | ${item.owner ?? '-'} | - | ${item.maxAgeDays ?? '-'} | - | invalid-date |`);
+                          lines.push('');
+                          lines.push(`- ${item.message}`);
+                          continue;
+                        }
+
+                        lines.push(`| ${item.name} | ${item.environment ?? '-'} | ${item.owner ?? '-'} | ${item.ageDays} | ${item.maxAgeDays} | ${item.daysUntilExpiry} | ${item.status} |`);
+                      }
+
+                      lines.push('');
+                      lines.push('### Required Actions');
+                      lines.push('- Rotate each listed secret in GitHub environment settings.');
+                      lines.push('- Update `lastRotated` in `.github/security/secret-rotation-policy.json`.');
+                      lines.push('- Re-run this workflow to confirm the reminder clears.');
+
+                      const body = lines.join('\n');
+
+                      if (trackingIssue) {
+                        await github.rest.issues.update({
+                          owner,
+                          repo,
+                          issue_number: trackingIssue.number,
+                          body,
+                          state: 'open',
+                          title: issueTitle
+                        });
+                        core.info(`Updated reminder issue #${trackingIssue.number}.`);
+                      } else {
+                        const created = await github.rest.issues.create({
+                          owner,
+                          repo,
+                          title: issueTitle,
+                          body,
+                          labels: issueLabels
+                        });
+                        core.info(`Created reminder issue #${created.data.number}.`);
+                      }


### PR DESCRIPTION
## Summary

Deploys the **GH-AW Secret Rotation Reminder** (T2 Advisor) to AgentCraftworks-CE.

### What's included

1. **`.github/security/secret-rotation-policy.json`** — Tracks 3 secrets:
   - `GH_CE_APP_PRIVATE_KEY` (GitHub CE App private key)
   - `GH_CE_WEBHOOK_SECRET` (webhook secret)
   - `POSTGRES_PASSWORD` (PostgreSQL database password)
2. **`.github/workflows/ghaw-secret-rotation-reminder.yml`** — Runs weekly (Monday 15:17 UTC) and on manual dispatch; creates/updates a GitHub issue when secrets are due or overdue for rotation

### Linked Issues

- Part of **Epic #32** ([AgentCraftworks-PlatformOps](https://github.com/AgentCraftworks/AgentCraftworks-PlatformOps/issues/32))
- Resolves **Issue #35** ([Deploy Secret Rotation Reminder org-wide](https://github.com/AgentCraftworks/AgentCraftworks-PlatformOps/issues/35)) — CE portion

### Note
The `lastRotated` dates in the policy JSON are set to 2026-03-10. Please verify these match actual last rotation dates.