### PR TITLE
feat: Add ghaw-config.json and config-driven workflow control (P3 #39)

### DIFF
--- a/.github/ghaw-config.json
+++ b/.github/ghaw-config.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AgentCraftworks/AgentCraftworks-PlatformOps/main/docs/schemas/ghaw-config.schema.json",
+  "org": "AgentCraftworks",
+  "repo": "AgentCraftworks-CE",
+  "workflows": [
+    {
+      "id": "ghaw-workflow-health",
+      "name": "GH-AW: Workflow Health Manager",
+      "trigger": "schedule",
+      "schedule": { "cron": "0 7 * * 1-5" },
+      "enabled": true,
+      "outputDestinations": ["github-issue"],
+      "notificationChannels": ["none"]
+    },
+    {
+      "id": "ghaw-daily-test-improver",
+      "name": "GH-AW: Daily Test Improver",
+      "trigger": "schedule",
+      "schedule": { "cron": "0 9 * * 1-5" },
+      "enabled": true,
+      "outputDestinations": ["github-issue"],
+      "notificationChannels": ["none"]
+    },
+    {
+      "id": "ghaw-secret-rotation-reminder",
+      "name": "GH-AW: Secret Rotation Reminder",
+      "trigger": "schedule",
+      "schedule": { "cron": "17 15 * * 1" },
+      "enabled": true,
+      "outputDestinations": ["github-issue"],
+      "notificationChannels": ["none"]
+    },
+    {
+      "id": "ghaw-pr-fix",
+      "name": "GH-AW: PR Fix",
+      "trigger": "check_run",
+      "enabled": true,
+      "outputDestinations": ["github-pr-comment"],
+      "notificationChannels": ["none"]
+    },
+    {
+      "id": "ghaw-ci-coach",
+      "name": "GH-AW: CI Coach",
+      "trigger": "workflow_run",
+      "enabled": true,
+      "outputDestinations": ["github-pr-comment"],
+      "notificationChannels": ["none"]
+    },
+    {
+      "id": "ghaw-branch-policy-guard",
+      "name": "GH-AW: Branch Policy Guard",
+      "trigger": "pull_request",
+      "enabled": true,
+      "outputDestinations": ["github-pr-comment"],
+      "notificationChannels": ["none"]
+    },
+    {
+      "id": "ghaw-accessibility-review",
+      "name": "GH-AW: Accessibility Review",
+      "trigger": "pull_request",
+      "enabled": true,
+      "outputDestinations": ["github-pr-comment"],
+      "notificationChannels": ["none"]
+    },
+    {
+      "id": "ghaw-cli-consistency",
+      "name": "GH-AW: CLI Consistency Checker",
+      "trigger": "pull_request",
+      "enabled": true,
+      "outputDestinations": ["github-pr-comment"],
+      "notificationChannels": ["none"]
+    },
+    {
+      "id": "ghaw-changeset",
+      "name": "GH-AW: Changeset",
+      "trigger": "push",
+      "enabled": true,
+      "outputDestinations": ["log-only"],
+      "notificationChannels": ["none"]
+    },
+    {
+      "id": "ghaw-azd-service-tag-check",
+      "name": "GH-AW: azd Service-Tag Contract Check",
+      "trigger": "pull_request",
+      "enabled": true,
+      "outputDestinations": ["github-pr-comment"],
+      "notificationChannels": ["none"]
+    },
+    {
+      "id": "ghaw-staging-refresh",
+      "name": "Refresh staging branch after promotion",
+      "trigger": "pull_request",
+      "enabled": true,
+      "outputDestinations": ["log-only"],
+      "notificationChannels": ["none"]
+    }
+  ]
+}

--- a/.github/workflows/ghaw-daily-test-improver.yml
+++ b/.github/workflows/ghaw-daily-test-improver.yml
@@ -30,7 +30,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Check GH-AW config
+        id: ghaw-config
+        run: |
+          CONFIG=".github/ghaw-config.json"
+          WORKFLOW_ID="ghaw-daily-test-improver"
+          if [ -f "$CONFIG" ]; then
+            ENABLED=$(jq -r --arg id "$WORKFLOW_ID" '.workflows[] | select(.id == $id) | .enabled' "$CONFIG")
+            if [ "$ENABLED" = "false" ]; then
+              echo "::notice::Workflow $WORKFLOW_ID is disabled via ghaw-config.json — skipping."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
       - name: Setup Node.js
+        if: steps.ghaw-config.outputs.skip != 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "22"
@@ -38,10 +54,12 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
+        if: steps.ghaw-config.outputs.skip != 'true'
         working-directory: typescript
         run: npm ci
 
       - name: Analyze and suggest tests
+        if: steps.ghaw-config.outputs.skip != 'true'
         working-directory: typescript
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ghaw-workflow-health.yml
+++ b/.github/workflows/ghaw-workflow-health.yml
@@ -26,7 +26,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Check GH-AW config
+        id: ghaw-config
+        run: |
+          CONFIG=".github/ghaw-config.json"
+          WORKFLOW_ID="ghaw-workflow-health"
+          if [ -f "$CONFIG" ]; then
+            ENABLED=$(jq -r --arg id "$WORKFLOW_ID" '.workflows[] | select(.id == $id) | .enabled' "$CONFIG")
+            if [ "$ENABLED" = "false" ]; then
+              echo "::notice::Workflow $WORKFLOW_ID is disabled via ghaw-config.json — skipping."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
       - name: Setup Node.js
+        if: steps.ghaw-config.outputs.skip != 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "22"
@@ -34,10 +50,12 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
+        if: steps.ghaw-config.outputs.skip != 'true'
         working-directory: typescript
         run: npm ci
 
       - name: Check workflow health
+        if: steps.ghaw-config.outputs.skip != 'true'
         working-directory: typescript
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary\n\nDeploys `ghaw-config.json` and adds config-driven kill-switches to scheduled workflows.\n\n### Changes\n\n- **`.github/ghaw-config.json`** — Catalogs all 11 GHAW workflows with IDs, schedules, triggers, and enabled flags.\n- **`ghaw-workflow-health.yml`** — Added config check step after checkout; reads `enabled` flag via `jq`. Subsequent steps skipped when disabled.\n- **`ghaw-daily-test-improver.yml`** — Same config check pattern.\n\n### How It Works\n\nAfter checkout, a new step reads `.github/ghaw-config.json` with `jq` and checks the `enabled` flag for the current workflow ID. If `enabled: false`, workflow exits early with a notice. If the config file is missing, workflow runs normally (safe fallback).\n\n### Context\n\nPart of Epic #32 — GHAW Workflow Governance, Issue #39 (P3). Schema defined in AgentCraftworks-PlatformOps PR #44.