### PR TITLE
fix: add vulnerability reporting contact to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ If you discover a security vulnerability in AgentCraftworks Core, please report 
 
 1. **Do NOT open a public issue** for security vulnerabilities
 2. **Preferred:** Use [GitHub's private vulnerability reporting](https://github.com/AgentCraftworks/AgentCraftworks-CE/security/advisories/new) for this repository
-3. **Alternative:** Email **security@agentcraftworks.com**
+3. **Alternative:** Email **contact@agentcraftworks.com**
 4. Include:
    - Description of the vulnerability
    - Steps to reproduce


### PR DESCRIPTION
Adds security@agentcraftworks.com email and a direct link to GitHub private vulnerability reporting. Includes response time expectations and a note for forkers to update with their own contact.

Fixes #101