### PR TITLE
fix: update LICENSE copyright to AICraftworks, LLC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 AgentCraftworks
+Copyright (c) 2025 AICraftworks, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
AgentCraftworks is the product name; AICraftworks, LLC is the legal entity that holds copyright. Updates the LICENSE file to reflect the correct legal owner.