### PR TITLE
fix(smoke-tests): add health readiness wait + surface fetch error cause

### DIFF
--- a/typescript/smoke-test.ts
+++ b/typescript/smoke-test.ts
@@ -29,8 +29,15 @@ async function test(name: string, fn: () => Promise<void>): Promise<void> {
     console.log(`✓ ${name} (${Date.now() - start}ms)`);
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
-    results.push({ name, passed: false, error: errorMsg, duration: Date.now() - start });
-    console.log(`✗ ${name} (${Date.now() - start}ms)\n  Error: ${errorMsg}`);
+    const cause = error instanceof Error ? (error as { cause?: unknown }).cause : undefined;
+    const causeMsg =
+      cause instanceof Error
+        ? ` (cause: ${cause.message})`
+        : cause != null
+          ? ` (cause: ${String(cause)})`
+          : "";
+    results.push({ name, passed: false, error: `${errorMsg}${causeMsg}`, duration: Date.now() - start });
+    console.log(`✗ ${name} (${Date.now() - start}ms)\n  Error: ${errorMsg}${causeMsg}`);
   }
 }
 


### PR DESCRIPTION
## Summary

Resolves the **smoke test failures** blocking PR#108 (staging -> main).

### Root Cause

`az containerapp update` exits 0 when configuration is updated, but the container revision may still be starting. Smoke tests were hitting a service that wasn't healthy yet, returning `fetch failed` (ECONNREFUSED/ENOTFOUND).

### Changes

**`typescript/smoke-test.ts`** (committed) — surfaces the underlying `cause` from `TypeError: fetch failed` so ECONNREFUSED / ENOTFOUND appear in CI logs.

**`.github/workflows/deploy-staging.yml`** — add this step to the `smoke-tests` job between `Install dependencies` and `Run TypeScript smoke tests`:

```yaml
      - name: Wait for staging service to be healthy
        env:
          BASE_URL: ${{ secrets.TYPESCRIPT_STAGING_URL }}
        run: |
          echo "Waiting for staging service at ${BASE_URL}/health ..."
          for i in $(seq 1 18); do
            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${BASE_URL}/health" 2>/dev/null || echo "000")
            if [ "$HTTP_STATUS" = "200" ]; then
              echo "Service healthy (attempt $i)"
              exit 0
            fi
            echo "  Attempt $i/18: HTTP ${HTTP_STATUS} - retrying in 10s..."
            sleep 10
          done
          echo "Service did not become healthy within 3 minutes."
          exit 1
```

> Note: The workflow file change can be applied via the GitHub web editor at `.github/workflows/deploy-staging.yml` on this branch.

## Engagement Level
T2/T4 - workflow change affects staging deployment gate only.