### PR TITLE
docs: Add Enterprise capabilities reference to CE README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Pull Request / Push Event
 | **CODEOWNERS Routing** | Events routed to the right agent based on ownership rules |
 | **Webhook Handling** | Handles GitHub PR, push, issue, and workflow events |
 | **GitHub App Scaffold** | Drop-in GitHub App: one install, works across all repos in your org |
+| **Enterprise Upgrade Path** | Seamless upgrade to Rate Governor, Squad Coordinator, Aspire Integration, and Governance Gates — same finite state machine, same MCP tools, more power |
 
 ## Architecture
 
@@ -131,7 +132,21 @@ AgentCraftworks Community Edition ships a fully compliant Model Context Protocol
 
 ## Enterprise Edition
 
-AgentCraftworks also powers enterprise deployments with additional incident response automation, self-healing orchestration, and governance monitoring. Learn more at [AgentCraftworks.com](https://agentcraftworks.com).
+The paid [AgentCraftworks Enterprise](https://agentcraftworks.com) extends CE with advanced orchestration and governance capabilities:
+
+| Enterprise Feature | What It Adds Over CE |
+|---|---|
+| **Rate Governor** | 6-pattern adaptive rate limiting — traffic light throttling, shared token pool, predictive circuit breaker, cascade detection, lease cleanup, and priority retry windows |
+| **Squad Coordinator** | Multi-agent orchestration — MCP capability detection, CLI fallback chains (`MCP → CLI → filesystem`), team configuration, and response mode selection |
+| **Aspire Integration** | .NET Aspire CLI bridge for distributed tracing, health checks, and observability dashboards across agent squads |
+| **Governance Gates** | Pre/post-execution policy enforcement middleware — validates trust scores, action tiers, and environment caps before every agent action |
+| **Promotion Engine** | Graduated rollout (staging → canary → production) with automatic rollback on gate failures |
+| **Audit Trail** | Full rate-limiting audit log — 429 events, circuit breaker transitions, zone changes, and lease reclaims |
+| **Quarantine Bridge** | Abuse detection and automatic quarantine for agents exceeding rate thresholds |
+
+All Enterprise features build on the same finite state machine (FSM), CODEOWNERS routing, and MCP tool interface that CE provides — they add the orchestration and governance layers needed for production-scale multi-agent workflows.
+
+Learn more at [AgentCraftworks.com](https://agentcraftworks.com).
 
 ## Fork & Customize
 


### PR DESCRIPTION
Adds an Enterprise Upgrade Path feature row and expands the Enterprise Edition section with a detailed comparison table showing Rate Governor, Squad Coordinator, Aspire Integration, Governance Gates, Promotion Engine, Audit Trail, and Quarantine Bridge.

Re-creation of orphaned PR #144 on a clean branch from staging.

Closes AgentCraftworks/AgentCraftworks#674