### PR TITLE
fix(link-checker): anchor domain regex patterns to prevent arbitrary host matching

### DIFF
--- a/typescript/src/jobs/link-checker.ts
+++ b/typescript/src/jobs/link-checker.ts
@@ -41,12 +41,12 @@ const URL_REPLACEMENTS: UrlReplacement[] = [
     reason: "Upgrade to HTTPS for security",
   },
   {
-    pattern: /docs\.microsoft\.com/g,
+    pattern: /(?<=https?:\/\/(?:www\.)?)docs\.microsoft\.com(?=\/|$)/g,
     replacement: "learn.microsoft.com",
     reason: "Microsoft Docs migrated to Microsoft Learn",
   },
   {
-    pattern: /aka\.ms\/deprecated/g,
+    pattern: /(?<=https?:\/\/)aka\.ms\/deprecated(?=[?#/\s]|$)/g,
     replacement: "learn.microsoft.com",
     reason: "Deprecated aka.ms link",
   },
@@ -56,7 +56,7 @@ const URL_REPLACEMENTS: UrlReplacement[] = [
     reason: "Many repos renamed master to main",
   },
   {
-    pattern: /travis-ci\.org/g,
+    pattern: /(?<=https?:\/\/(?:www\.)?)travis-ci\.org(?=\/|$)/g,
     replacement: "travis-ci.com",
     reason: "Travis CI migrated to .com",
   },


### PR DESCRIPTION
## Fixes CodeQL Alerts #6, #7, #8 — Missing regular expression anchor

Addresses the three GitHub Advanced Security / CodeQL review comments on PR #153.

### Problem
Three regex patterns in \URL_REPLACEMENTS\ had no anchors, allowing them to match arbitrary substrings within a URL — e.g. matching \docs.microsoft.com\ inside a path segment like \.../evil.docs.microsoft.com.attacker.com/...\.

### Fix
Added lookbehind anchors (\(?<=https?:\/\/...)\) and lookahead anchors (\(?=\/|\$)\) to each unanchored domain pattern so they only match when the domain is in the hostname position of a URL:

| Pattern | Before | After |
|---------|--------|-------|
| docs.microsoft.com | \/docs\\.microsoft\\.com/g\ | \/(?<=https?:\\/\\/(?:www\\.)?)\docs\\.microsoft\\.com\(?=\\/|\$)/g\ |
| aka.ms/deprecated | \/aka\\.ms\\/deprecated/g\ | \/(?<=https?:\\/\\/)aka\\.ms\\/deprecated(?=[?#/\\s]\|$)/g\ |
| travis-ci.org | \/travis-ci\\.org/g\ | \/(?<=https?:\\/\\/(?:www\\.)?)\	ravis-ci\\.org\(?=\\/|\$)/g\ |

Resolves: CodeQL code-scanning alerts [#6](https://github.com/AgentCraftworks/AgentCraftworks-CE/security/code-scanning/6), [#7](https://github.com/AgentCraftworks/AgentCraftworks-CE/security/code-scanning/7), [#8](https://github.com/AgentCraftworks/AgentCraftworks-CE/security/code-scanning/8)