### PR TITLE
ci: fix CLA workflow — continue-on-error when GitHub App not installed on repo

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Generate GitHub App Token
         id: app-token
         if: steps.check-secrets.outputs.secrets-available == 'true'
+        continue-on-error: true
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.GH_CE_APP_ID }}


### PR DESCRIPTION
The CLA workflow fails hard when GH_CE_APP_ID is configured but the GitHub App is not installed on this specific repository. The app-token step throws a 404 before the GITHUB_TOKEN fallback can run.

Fix: add continue-on-error: true to the Generate GitHub App Token step. The existing Resolve CLA auth token step then correctly falls back to GITHUB_TOKEN.

Note: PR #157 is currently showing a CLA failure that is cosmetic (CLA is not a required status check on staging). Once this fix is merged, all future CLA runs will use GITHUB_TOKEN as fallback.

cx:exempt - CI workflow fix, no customer-visible surface